### PR TITLE
Update de.json to fix wrong German translations of moon phases

### DIFF
--- a/custom_components/lunar_phase/translations/de.json
+++ b/custom_components/lunar_phase/translations/de.json
@@ -32,9 +32,9 @@
             "moon_phase": {
                 "name": "Mondphase",
                 "state": {
-                    "first_quarter": "Zunehmender Mond",
+                    "first_quarter": "Zunehmender Halbmond",
                     "full_moon": "Vollmond",
-                    "last_quarter": "Zunehmender Dreiviertelmond",
+                    "last_quarter": "Abnehmender Halbmond",
                     "new_moon": "Neumond",
                     "waning_crescent": "Abnehmender Sichelmond",
                     "waning_gibbous": "Abnehmender Dreiviertelmond",
@@ -44,9 +44,9 @@
             },
             "next_phase": {
                 "state": {
-                    "first_quarter": "Zunehmender Mond",
+                    "first_quarter": "Zunehmender Halbmond",
                     "full_moon": "Vollmond",
-                    "last_quarter": "Zunehmender Dreiviertelmond",
+                    "last_quarter": "Abnehmender Halbmond",
                     "new_moon": "Neumond"
                 }
             }


### PR DESCRIPTION
This addresses [[Bug] Wrong German translations for the moon phases](https://github.com/ngocjohn/lunar-phase/issues/9#top)

fixing the wrong German translations for the occurrences of  "first_quarter" and "last_quarter".

Makes it consistent with the same changes to the lunar-phase-card in https://github.com/ngocjohn/lunar-phase-card/pull/43