### PR TITLE
Bugfix: Ensure date variables are updated before sensors are updated.

### DIFF
--- a/custom_components/lunar_phase/moon.py
+++ b/custom_components/lunar_phase/moon.py
@@ -56,8 +56,7 @@ class MoonCalc:
         self._latitude = latitude
         self._longitude = longitude
         self._timezone = timezone
-        self.today = dt_util.now().replace(tzinfo=tz.UTC)
-        self.date = datetime.datetime.now()
+        self.update_date_variables()
         self.observer = ephem.Observer()
         self.location = None
         self._phase_name = None
@@ -187,7 +186,17 @@ class MoonCalc:
 
     def update(self):
         """Update the MoonCalc object."""
+        self.update_date_variables()
+        
         self.get_moon_illumination()
         self.get_moon_position()
         self.get_moon_times()
         self.get_next_type_phase()
+
+    def update_date_variables(self):
+        """Set the current date to the relevant variables."""
+        self.today = dt_util.now().replace(tzinfo=tz.UTC)
+        self.date = datetime.datetime.now()
+
+        if hasattr(self, "observer") and self.observer is not None:
+            self.observer.date = self.today

--- a/custom_components/lunar_phase/moon.py
+++ b/custom_components/lunar_phase/moon.py
@@ -186,8 +186,10 @@ class MoonCalc:
 
     def update(self):
         """Update the MoonCalc object."""
+        # Update date variables before moon sensors update
         self.update_date_variables()
         
+        # Proceed with moon data calculations
         self.get_moon_illumination()
         self.get_moon_position()
         self.get_moon_times()


### PR DESCRIPTION
Refactor the date initialisation into a separate method to be called during the initialisation phase and before sensor updates.

This aims to fix https://github.com/ngocjohn/lunar-phase/issues/30 
