### PR TITLE
fix: (moon.py) handle None return from get_event_time when moon doesn…

### DIFF
--- a/custom_components/lunar_phase/moon.py
+++ b/custom_components/lunar_phase/moon.py
@@ -107,6 +107,8 @@ class MoonCalc:
     def get_event_time(self, event):
         """Return the event time as a timestamp with timezone information."""
         event_time = self._moon_times.get(event)
+        if event_time is None:
+            return None
         config_timezone = tz.gettz(self.location.timezone)
         return event_time.astimezone(config_timezone)
 


### PR DESCRIPTION
…'t rise/set

Fixes #35

## Problem

`get_event_time()` calls `.astimezone()` directly on the return value of `self._moon_times.get(event)` without checking for `None` first.

`MoonScript.get_moon_times()` only adds `rise`, `set`, and `highest` keys to its result dict when a horizon crossing is actually found within the 24-hour window. At high latitudes this legitimately doesn't happen on some days; the moon simply doesn't rise or set.

When a key is missing,
`.get(event)` returns `None`, and the subsequent `.astimezone()` call raises `AttributeError: 'NoneType' object has no attribute 'astimezone'`, which causes the coordinator to fail on first refresh and the entire integration to become unavailable.

## Fix

Early return `None` if `event_time` is missing, letting the sensor attribute surface as unknown rather than taking down the whole integration.

## Testing

Reproducible with a high-latitude location (e.g. northern Norway, which is my case). The issue may be absent depending on date.