### PR TITLE
feat: add lunar illuminance sensor

### DIFF
--- a/custom_components/lunar_phase/const.py
+++ b/custom_components/lunar_phase/const.py
@@ -36,6 +36,7 @@ STATE_ATTR_ALTITUDE = "moon_altitude_deg"
 STATE_ATTR_AZIMUTH = "moon_azimuth_deg"
 STATE_ATTR_PARALLACTIC_ANGLE = "moon_parallactic_angle_deg"
 STATE_ATTR_NEXT_PHASE = "next_phase"
+STATE_ATTR_ILLUMINANCE = "moon_illuminance"
 
 EXTRA_ATTR_AZIMUTH = "moon_azimuth_radians"
 EXTRA_ATTR_ALTITUDE = "moon_altitude_radians"
@@ -223,5 +224,16 @@ BASE_LUNAR_SENSORS = {
         [EXTRA_ATTR_NEXT_PHASE],
         None,
         EntityCategory.DIAGNOSTIC,
+    ],
+    STATE_ATTR_ILLUMINANCE: [
+        "Moon Illuminance",
+        STATE_ATTR_ILLUMINANCE,
+        "mdi:brightness-6",
+        SensorDeviceClass.ILLUMINANCE,
+        SensorStateClass.MEASUREMENT,
+        "lx",
+        [],
+        4,
+        None,
     ],
 }

--- a/custom_components/lunar_phase/moon.py
+++ b/custom_components/lunar_phase/moon.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+import math
 
 from astral import LocationInfo
 from dateutil import tz
@@ -19,6 +20,7 @@ from .const import (
     STATE_ATTR_ALTITUDE,
     STATE_ATTR_AZIMUTH,
     STATE_ATTR_DISTANCE_KM,
+    STATE_ATTR_ILLUMINANCE,
     STATE_ATTR_ILLUMINATION_FRACTION,
     STATE_ATTR_NEXT_FIRST,
     STATE_ATTR_NEXT_FULL,
@@ -141,6 +143,21 @@ class MoonCalc:
             return fraction * 100
         return None
 
+    def get_moon_illuminance(self):
+        """Return estimated moonlight illuminance in lux (Krisciunas-Schaefer model)."""
+        fraction = self._moon_illumination.get("fraction")
+        altitude_deg = self._moon_position.get("altitudeDegrees")
+        distance = self._moon_position.get("distance")
+        if fraction is None or altitude_deg is None or not distance:
+            return None
+        zenith_angle = math.radians(90.0 - altitude_deg)
+        cos_z = math.cos(zenith_angle)
+        if cos_z <= 0:
+            return 0.0
+        avg_distance = 384400.0
+        # E0 = 0.25 lux — full moon at zenith at average distance
+        return round(0.25 * fraction * cos_z * (avg_distance / distance) ** 2, 6)
+
     def get_next_type_phase(self):
         """Return the next type of moon phase."""
         next_obj = self._moon_illumination.get("next")
@@ -164,6 +181,7 @@ class MoonCalc:
                 "parallacticAngleDegrees"
             ),
             STATE_ATTR_ILLUMINATION_FRACTION: self.get_moon_illumination_fraction(),
+            STATE_ATTR_ILLUMINANCE: self.get_moon_illuminance(),
             STATE_ATTR_NEXT_FULL: self.get_next_moon_phase("fullMoon"),
             STATE_ATTR_NEXT_NEW: self.get_next_moon_phase("newMoon"),
             STATE_ATTR_NEXT_THIRD: self.get_next_moon_phase("thirdQuarter"),

--- a/custom_components/lunar_phase/translations/cs.json
+++ b/custom_components/lunar_phase/translations/cs.json
@@ -41,6 +41,9 @@
                     "last_quarter": "Poslední čtvrť",
                     "new_moon": "Novoluní"
                 }
+            },
+            "moon_illuminance": {
+                "name": "Měsíční osvětlenost"
             }
         }
     }

--- a/custom_components/lunar_phase/translations/de.json
+++ b/custom_components/lunar_phase/translations/de.json
@@ -41,6 +41,9 @@
                     "last_quarter": "Abnehmender Halbmond",
                     "new_moon": "Neumond"
                 }
+            },
+            "moon_illuminance": {
+                "name": "Mondbeleuchtungsstärke"
             }
         }
     }

--- a/custom_components/lunar_phase/translations/en.json
+++ b/custom_components/lunar_phase/translations/en.json
@@ -40,6 +40,9 @@
                     "last_quarter": "Last quarter",
                     "new_moon": "New moon"
                 }
+            },
+            "moon_illuminance": {
+                "name": "Moon Illuminance"
             }
         }
     },

--- a/custom_components/lunar_phase/translations/fr.json
+++ b/custom_components/lunar_phase/translations/fr.json
@@ -40,6 +40,9 @@
                     "last_quarter": "Dernier quartier",
                     "new_moon": "Nouvelle lune"
                 }
+            },
+            "moon_illuminance": {
+                "name": "Éclairement lunaire"
             }
         }
     },

--- a/custom_components/lunar_phase/translations/id.json
+++ b/custom_components/lunar_phase/translations/id.json
@@ -41,6 +41,9 @@
                     "last_quarter": "Bulan Paruh akhir",
                     "new_moon": "Bulan Baru"
                 }
+            },
+            "moon_illuminance": {
+                "name": "Iluminansi Bulan"
             }
         }
     }

--- a/custom_components/lunar_phase/translations/it.json
+++ b/custom_components/lunar_phase/translations/it.json
@@ -40,6 +40,9 @@
           "last_quarter": "Ultimo quarto",
           "new_moon": "Luna nuova"
         }
+      },
+      "moon_illuminance": {
+        "name": "Illuminamento lunare"
       }
     }
   },

--- a/custom_components/lunar_phase/translations/nl.json
+++ b/custom_components/lunar_phase/translations/nl.json
@@ -40,6 +40,9 @@
                     "last_quarter": "Laatste kwartier",
                     "new_moon": "Nieuwe maan"
                 }
+            },
+            "moon_illuminance": {
+                "name": "Maanverlichtingssterkte"
             }
         }
     },


### PR DESCRIPTION
## Summary

- Adds `sensor.<location>_moon_illuminance` (unit: lx) to every configured location
- Uses the Krisciunas-Schaefer empirical model: `E ≈ 0.25 · f · cos(z) · (D_avg/D)²`
- Returns `0.0 lx` when the moon is below the horizon
- All inputs come from existing position/illumination data — no new dependencies
- Translation names added for all 7 supported languages

Closes #25

## Test plan

- [ ] Sensor appears in device list after HA restart
- [ ] Value is `0.0 lx` when moon altitude < 0°
- [ ] Value increases as moon rises (expect ~0.1–0.25 lx near full moon at zenith)
- [ ] Unit is `lx`, device class `illuminance`
- [ ] No errors in HA logs on startup